### PR TITLE
Rename KubeCtx to KubeContext to make it conform to the API contract

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -3,7 +3,7 @@ package flags
 // CommonFlags are common to all apis
 // TODO: We can maybe define setter funcs to allow setting these easily
 type CommonFlags struct {
-	KubeCtx       string `json:"kube_context,omitempty"`
+	KubeContext   string `json:"kube_context,omitempty"`
 	KubeToken     string `json:"kube_token,omitempty"`
 	KubeAPIServer string `json:"kube_apiserver,omitempty"`
 	Namespace     string


### PR DESCRIPTION
This PR renames the kubectx flag to KubeContext to make it conform to the api contract